### PR TITLE
Added extensions for adding and validating menu options.

### DIFF
--- a/src/Extensions/Menu/AddOption.cs
+++ b/src/Extensions/Menu/AddOption.cs
@@ -1,0 +1,6 @@
+﻿namespace dotmenu;
+
+public static class MenuExtensions
+{
+    
+}

--- a/src/Extensions/Menu/AddOption.cs
+++ b/src/Extensions/Menu/AddOption.cs
@@ -51,7 +51,8 @@ public static partial class MenuExtensions
         string? selector = null)
     {
         ArgumentNullException.ThrowIfNull(menu, nameof(menu));
-        ArgumentException.ThrowIfNullOrWhiteSpace(text, nameof(text));
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ArgumentException("The text must be a non-empty string.", nameof(text));
         
         var option = new Option(text, action, hidden, disabled, fg, bg, selectedFg, selectedBg, optionPrefix, selector);
         option.Validate();

--- a/src/Extensions/Menu/AddOption.cs
+++ b/src/Extensions/Menu/AddOption.cs
@@ -1,6 +1,32 @@
 ﻿namespace dotmenu;
 
-public static class MenuExtensions
+/// <summary>
+/// Defines extension methods for the <see cref="Menu" /> class.
+/// </summary>
+public static partial class MenuExtensions
 {
-    
+    /// <summary>
+    /// Adds a predefined option to the menu.
+    /// </summary>
+    /// <param name="menu">The menu to add the option to.</param>
+    /// <typeparam name="TOption">Specifies the type of option to add.</typeparam>
+    /// <returns>The menu with the added option.</returns>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="menu"/> is <see langword="null"/> -or-
+    ///     Validation the created option throws <see cref="ArgumentNullException"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     Validation the created option throws <see cref="ArgumentException"/>.
+    /// </exception>
+    public static Menu AddOption<TOption>(this Menu menu)
+        where TOption : Option, new()
+    {
+        ArgumentNullException.ThrowIfNull(menu, nameof(menu));
+        
+        var option = new TOption();
+        option.Validate();
+        
+        menu.options.Add(option);
+        return menu;
+    }
 }

--- a/src/Extensions/Menu/AddOption.cs
+++ b/src/Extensions/Menu/AddOption.cs
@@ -6,24 +6,54 @@
 public static partial class MenuExtensions
 {
     /// <summary>
-    /// Adds a predefined option to the menu.
+    /// Adds a new option to the menu.
     /// </summary>
     /// <param name="menu">The menu to add the option to.</param>
-    /// <typeparam name="TOption">Specifies the type of option to add.</typeparam>
+    /// <param name="text">The text to be displayed for this option.</param>
+    /// <param name="action">The action to be performed after this option is chosen.</param>
+    /// <param name="hidden">
+    ///     <see langword="true"/> if the option is hidden; otherwise, <see langword="false"/>.
+    /// </param>
+    /// <param name="disabled">
+    ///     <see langword="true"/> if the option is disabled; otherwise, <see langword="false"/>.
+    /// </param>
+    /// <param name="fg">The foreground color of the option.</param>
+    /// <param name="bg">The background color of the option.</param>
+    /// <param name="selectedFg">The foreground color of the option when selected.</param>
+    /// <param name="selectedBg">The background color of the option when selected.</param>
+    /// <param name="optionPrefix">
+    ///     The value to be displayed before the text of the option when it is not selected.
+    /// </param>
+    /// <param name="selector">
+    ///     The value to be displayed before the text of the option when it is selected.
+    /// </param>
     /// <returns>The menu with the added option.</returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="menu"/> is <see langword="null"/> -or-
-    ///     Validation the created option throws <see cref="ArgumentNullException"/>.
+    ///     <paramref name="text"/> is <see langword="null"/> -or-
+    ///     validation the created option throws <see cref="ArgumentNullException"/>.
     /// </exception>
     /// <exception cref="ArgumentException">
-    ///     Validation the created option throws <see cref="ArgumentException"/>.
+    ///     <paramref name="text"/> is <see langword="null"/>, empty, or whitespace -or-
+    ///     validation the created option throws <see cref="ArgumentException"/>.
     /// </exception>
-    public static Menu AddOption<TOption>(this Menu menu)
-        where TOption : Option, new()
+    public static Menu AddOption(
+        this Menu menu,
+        string text,
+        Action? action = null,
+        bool? hidden = null,
+        bool? disabled = null,
+        OptionColor? fg = null,
+        OptionColor? bg = null,
+        OptionColor? selectedFg = null,
+        OptionColor? selectedBg = null,
+        string? optionPrefix = null,
+        string? selector = null)
     {
         ArgumentNullException.ThrowIfNull(menu, nameof(menu));
+        ArgumentException.ThrowIfNullOrWhiteSpace(text, nameof(text));
         
-        var option = new TOption();
+        var option = new Option(text, action, hidden, disabled, fg, bg, selectedFg, selectedBg, optionPrefix, selector);
         option.Validate();
         
         menu.options.Add(option);

--- a/src/Extensions/Menu/AddOptionByType.cs
+++ b/src/Extensions/Menu/AddOptionByType.cs
@@ -1,0 +1,32 @@
+﻿namespace dotmenu;
+
+/// <summary>
+/// Defines extension methods for the <see cref="Menu" /> class.
+/// </summary>
+public static partial class MenuExtensions
+{
+    /// <summary>
+    /// Adds a predefined option to the menu.
+    /// </summary>
+    /// <param name="menu">The menu to add the option to.</param>
+    /// <typeparam name="TOption">Specifies the type of option to add.</typeparam>
+    /// <returns>The menu with the added option.</returns>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="menu"/> is <see langword="null"/> -or-
+    ///     Validation the created option throws <see cref="ArgumentNullException"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     Validation the created option throws <see cref="ArgumentException"/>.
+    /// </exception>
+    public static Menu AddOption<TOption>(this Menu menu)
+        where TOption : Option, new()
+    {
+        ArgumentNullException.ThrowIfNull(menu, nameof(menu));
+        
+        var option = new TOption();
+        option.Validate();
+        
+        menu.options.Add(option);
+        return menu;
+    }
+}

--- a/src/Extensions/Menu/AddOptionByType.cs
+++ b/src/Extensions/Menu/AddOptionByType.cs
@@ -13,10 +13,10 @@ public static partial class MenuExtensions
     /// <returns>The menu with the added option.</returns>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="menu"/> is <see langword="null"/> -or-
-    ///     Validation the created option throws <see cref="ArgumentNullException"/>.
+    ///     validation the created option throws <see cref="ArgumentNullException"/>.
     /// </exception>
     /// <exception cref="ArgumentException">
-    ///     Validation the created option throws <see cref="ArgumentException"/>.
+    ///     validation the created option throws <see cref="ArgumentException"/>.
     /// </exception>
     public static Menu AddOption<TOption>(this Menu menu)
         where TOption : Option, new()

--- a/src/Extensions/Option/Validate.cs
+++ b/src/Extensions/Option/Validate.cs
@@ -22,6 +22,7 @@ public static partial class OptionExtensions
         ArgumentNullException.ThrowIfNull(option.TextFunction, nameof(option.TextFunction));
 
         var text = option.TextFunction.Invoke();
-        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ArgumentException("The text function must return a non-empty string.", nameof(option));
     }
 }

--- a/src/Extensions/Option/Validate.cs
+++ b/src/Extensions/Option/Validate.cs
@@ -1,0 +1,27 @@
+﻿namespace dotmenu;
+
+/// <summary>
+/// Defines extension methods for the <see cref="Option" /> class.
+/// </summary>
+public static partial class OptionExtensions
+{
+    /// <summary>
+    /// Validates the provided <see cref="Option" />.
+    /// </summary>
+    /// <param name="option">The option to validate.</param>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="option"/> is <see langword="null"/> -or-
+    ///     <see cref="Option.TextFunction"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     <see cref="Option.TextFunction"/> returns <see langword="null"/>, empty, or whitespace.
+    /// </exception>
+    public static void Validate(this Option option)
+    {
+        ArgumentNullException.ThrowIfNull(option, nameof(option));
+        ArgumentNullException.ThrowIfNull(option.TextFunction, nameof(option.TextFunction));
+
+        var text = option.TextFunction.Invoke();
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+    }
+}

--- a/src/Option.cs
+++ b/src/Option.cs
@@ -50,6 +50,51 @@ public class Option
     }
 
     /// <summary>
+    /// Creates a new <see cref="Option" /> with the provided text.
+    /// </summary>
+    /// <param name="text">The text to be displayed for this option.</param>
+    /// <param name="action">The action to be performed after this option is chosen.</param>
+    /// <param name="hidden">
+    ///     <see langword="true"/> if the option is hidden; otherwise, <see langword="false"/>.
+    /// </param>
+    /// <param name="disabled">
+    ///     <see langword="true"/> if the option is disabled; otherwise, <see langword="false"/>.
+    /// </param>
+    /// <param name="fg">The foreground color of this option.</param>
+    /// <param name="bg">The background color of this option.</param>
+    /// <param name="selectedFg">The foreground color of this option when selected.</param>
+    /// <param name="selectedBg">The background color of this option when selected.</param>
+    /// <param name="optionPrefix">
+    ///     The value to be displayed before the text of this option when it is not selected.
+    /// </param>
+    /// <param name="selector">
+    ///     The value to be displayed before the text of this option when it is selected.
+    /// </param>
+    public Option(
+        string text,
+        Action? action = null,
+        bool? hidden = null,
+        bool? disabled = null,
+        OptionColor? fg = null,
+        OptionColor? bg = null,
+        OptionColor? selectedFg = null,
+        OptionColor? selectedBg = null,
+        string? optionPrefix = null,
+        string? selector = null)
+    {
+        TextFunction = () => text;
+        Action = action;
+        Hidden = hidden;
+        Disabled = disabled;
+        Fg = fg;
+        Bg = bg;
+        SelectedFg = selectedFg;
+        SelectedBg = selectedBg;
+        OptionPrefix = optionPrefix;
+        Selector = selector;
+    }
+
+    /// <summary>
     /// Sets the text function for this option.
     /// </summary>
     /// <param name="textFunction">The function providing text content for this option.</param>


### PR DESCRIPTION
# TL;DR

This PR adds support for the following features:

- Option Validation
- Add Predefined Options by Type
- Add Options (on the fly)

## Option Validation

`Option` instances can't be displayed without valid text to display them, so a `TextFunction` value is required, additionally that value should be non-empty (e.g. not `null`, empty, or just whitespace). Now, you can validate options prior to working with them:

```cs
var option = new Option(text: null);
option.Validate(); // throws ArgumentException
```

## Add Predefined Options by Type

Given that C# is an object oriented language, consumers will likely desire the cleanliness provided by predefining their options. This feature allows them to add their predefined options types to the menu with a nice and clean flow:

```cs
public sealed class PredefinedOption()
    : Option(text: "sample");

...
menu.AddOption<PredefinedOption>();
```

## Add Options (on the fly)

This extension was created for consistency with the `Option` constructor added by this PR and improved flexibility when adding an option to the menu:

```cs
menu.AddOption(text: "Play", action: StartGame);
```